### PR TITLE
Fix inconsistent removal of trailing fwd slash across OS

### DIFF
--- a/R/dp_deploy.R
+++ b/R/dp_deploy.R
@@ -69,7 +69,7 @@ dp_deployCore.s3_board <- function(conf, project_path, d, dlog, git_info,
   }
 
   board <- pins::board_s3(
-    prefix = file.path("daap/"),
+    prefix = "daap/",
     bucket = conf$board_params$bucket_name,
     region = conf$board_params$region,
     access_key = aws_creds$key,

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,7 +74,7 @@ dpboardlog_update <- function(conf, git_info, dlog = NULL,
                               pin_version = character(0)) {
   board_object <- dpi::dp_connect(
     board_params = conf$board_params, creds = conf$creds,
-    board_subdir = file.path("daap/")
+    board_subdir = "daap/"
   )
 
   if (board_object$board == "pins_board_folder") {


### PR DESCRIPTION
**Why**: Part of the fix to address amashadihossein/dpi#38. Similar changes were done in all 3 core `daapr` pkgs: `dpi`, `dpdeploy`, `dpbuild`. For the fixes to address the underlying issue, all fixes will need to be incorporated.

**What**: Removed `file.path` calls when such calls impact AWS S3 path and instead explicitly passed the path with fwd slash as required by AWS S3 object path.

**Background**: `file.path` removes the trailing forward slash in a path in Windows OS, while it keeps it in Uinx. AWS S3 bucket paths require the trailing forward slash. As such, to make the behavior consistent across OS and inline with AWS S3 object path standards, we could remove the unnecessary `file.path` calls _when the path is used to specify S3 object storage_.