### PR TITLE
v0.3.0 fully deprecate board_alias

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dpdeploy
 Title: A package to manage deployment of data products
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: c(
     person(given = "Afshin", family = "Mashadi-Hossein", email ="amashadihossein@gmail.com", role = c("aut", "cre")),
     person(given = "Yue", family = "Jiang", email = "rivehill@gmail.com", role = "aut")
@@ -13,7 +13,7 @@ Imports:
     aws.signature,
     cli,
     dpbuild (>= 0.2.0),
-    dpi (>= 0.2.0),
+    dpi (>= 0.3.0),
     dplyr,
     ellipsis,
     fs,
@@ -22,7 +22,7 @@ Imports:
     lifecycle,
     magrittr,
     pins (>= 1.2.0),
-    pinsLabkey,
+    pinsLabkey (>= 0.2.0),
     purrr,
     rlang (>= 0.4.11),
     withr,
@@ -33,6 +33,6 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Remotes: 
     github::camorosi/pinsLabkey

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# dpdeploy 0.3.0
+
+* Removed references to `board_alias` (#34) as this argument is now deprecated with `pinsLabkey` v0.2.0
+* Addressed `dp_connect` issue on on windows related to removed of trailing slashes in s3 dirs
+
 # dpdeploy 0.2.0
 
 * Add back support for LabKey boards (#29). `pinsLabkey` is now required to work with LabKey boards

--- a/R/dp_deploy.R
+++ b/R/dp_deploy.R
@@ -69,7 +69,7 @@ dp_deployCore.s3_board <- function(conf, project_path, d, dlog, git_info,
   }
 
   board <- pins::board_s3(
-    prefix = file.path("daap/"),
+    prefix = "daap/",
     bucket = conf$board_params$bucket_name,
     region = conf$board_params$region,
     access_key = aws_creds$key,

--- a/R/dp_deploy.R
+++ b/R/dp_deploy.R
@@ -104,7 +104,7 @@ dp_deployCore.labkey_board <- function(conf, project_path, d, dlog, git_info,
   }
 
   board <- pinsLabkey::board_labkey(
-    board_alias = conf$board_params$board_alias,
+    cache_alias = conf$board_params$cache_alias,
     api_key = labkey_creds$api_key,
     base_url = conf$board_params$url,
     folder = conf$board_params$folder,

--- a/R/dpinput_sync.R
+++ b/R/dpinput_sync.R
@@ -18,8 +18,7 @@ dpinput_sync <- function(conf, input_map, verbose = F, ...) {
   if (verbose) {
     cli::cli_alert_info(glue::glue(
       "Starting sync to the ",
-      "{conf$board_params$board_type} remote: ",
-      "{conf$board_params$board_alias}"
+      "{conf$board_params$board_type} remote"
     ))
   }
 
@@ -121,7 +120,7 @@ init_board.labkey_board <- function(conf) {
   }
 
   pinsLabkey::board_labkey(
-    board_alias = conf$board_params$board_alias,
+    cache_alias = conf$board_params$cache_alias,
     api_key = labkey_creds$api_key,
     base_url = conf$board_params$url,
     folder = conf$board_params$folder,

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,7 +74,7 @@ dpboardlog_update <- function(conf, git_info, dlog = NULL,
                               pin_version = character(0)) {
   board_object <- dpi::dp_connect(
     board_params = conf$board_params, creds = conf$creds,
-    board_subdir = file.path("daap/")
+    board_subdir = "daap/"
   )
 
   if (board_object$board == "pins_board_folder") {


### PR DESCRIPTION
* Removed references to `board_alias` (#34) as this argument is now deprecated with `pinsLabkey` v0.2.0
* Addressed `dp_connect` issue on on windows related to removed of trailing slashes in s3 dirs

note: tests will fail until new dpi version is released